### PR TITLE
HELP-58644 Add RequireNew session option

### DIFF
--- a/mongo/client.go
+++ b/mongo/client.go
@@ -408,6 +408,9 @@ func (c *Client) StartSession(opts ...*options.SessionOptions) (Session, error) 
 	if sopts.Snapshot != nil {
 		coreOpts.Snapshot = sopts.Snapshot
 	}
+	if sopts.RequireNew != nil {
+		coreOpts.RequireNew = sopts.RequireNew
+	}
 
 	sess, err := session.NewClientSession(c.sessionPool, c.id, coreOpts)
 	if err != nil {

--- a/mongo/options/sessionoptions.go
+++ b/mongo/options/sessionoptions.go
@@ -48,6 +48,10 @@ type SessionOptions struct {
 	// be set to true if CausalConsistency is set to true. Transactions and write operations are not allowed on
 	// snapshot sessions and will error. The default value is false.
 	Snapshot *bool
+
+	// RequireNew ensures that a call to [Client.StartSession] creates a new
+	// server session rather than checking one out from the pool.
+	RequireNew *bool
 }
 
 // Session creates a new SessionOptions instance.
@@ -96,6 +100,12 @@ func (s *SessionOptions) SetSnapshot(b bool) *SessionOptions {
 	return s
 }
 
+// SetRequireNew sets the value for the RequireNew field.
+func (s *SessionOptions) SetRequireNew(b bool) *SessionOptions {
+	s.RequireNew = &b
+	return s
+}
+
 // MergeSessionOptions combines the given SessionOptions instances into a single SessionOptions in a last-one-wins
 // fashion.
 //
@@ -124,6 +134,9 @@ func MergeSessionOptions(opts ...*SessionOptions) *SessionOptions {
 		}
 		if opt.Snapshot != nil {
 			s.Snapshot = opt.Snapshot
+		}
+		if opt.RequireNew != nil {
+			s.RequireNew = opt.RequireNew
 		}
 	}
 	if s.CausalConsistency == nil && (s.Snapshot == nil || !*s.Snapshot) {

--- a/mongo/options/sessionoptions.go
+++ b/mongo/options/sessionoptions.go
@@ -49,7 +49,7 @@ type SessionOptions struct {
 	// snapshot sessions and will error. The default value is false.
 	Snapshot *bool
 
-	// RequireNew ensures that a call to [Client.StartSession] creates a new
+	// RequireNew ensures that starting a session with a client creates a new
 	// server session rather than checking one out from the pool.
 	RequireNew *bool
 }

--- a/mongo/options/sessionoptions.go
+++ b/mongo/options/sessionoptions.go
@@ -50,7 +50,8 @@ type SessionOptions struct {
 	Snapshot *bool
 
 	// RequireNew ensures that starting a session with a client creates a new
-	// server session rather than checking one out from the pool.
+	// server session rather than checking one out from the pool. Since this
+	// avoids pooling, closing the server session is up to the caller.
 	RequireNew *bool
 }
 

--- a/x/mongo/driver/session/client_session.go
+++ b/x/mongo/driver/session/client_session.go
@@ -236,6 +236,11 @@ func (c *Client) SetServer() error {
 	var err error
 	if c.RequireNew {
 		c.Server, err = newServerSession()
+
+		// Mark the server as dirty so that it won't be returned to the pool.
+		if c.Server != nil {
+			c.Server.MarkDirty()
+		}
 	} else {
 		c.Server, err = c.pool.GetSession()
 	}

--- a/x/mongo/driver/session/options.go
+++ b/x/mongo/driver/session/options.go
@@ -22,6 +22,7 @@ type ClientOptions struct {
 	DefaultReadPreference *readpref.ReadPref
 	DefaultMaxCommitTime  *time.Duration
 	Snapshot              *bool
+	RequireNew            *bool
 }
 
 // TransactionOptions represents all possible options for starting a transaction in a session.
@@ -55,6 +56,9 @@ func mergeClientOptions(opts ...*ClientOptions) *ClientOptions {
 		}
 		if opt.Snapshot != nil {
 			c.Snapshot = opt.Snapshot
+		}
+		if opt.RequireNew != nil {
+			c.RequireNew = opt.RequireNew
 		}
 	}
 


### PR DESCRIPTION
[HELP-58644](https://jira.mongodb.org/browse/HELP-58664)

Using a snapshot read concern with atClusterTime on a session may result in selecting a server from the server session pool created before atClusterTime, causing a WriteConflict. Due to this potential issue and the fact that it is only possible as of commit b79a739704f81b246414faca8e756ed7aca9a058, the Go Driver does not intend to officially support this use case. As a workaround that avoids nondeterministically tearing down the pool (see [here](https://mongodb.slack.com/archives/C7WJZNUTA/p1713824993166989?thread_ts=1713799605.626439&cid=C7WJZNUTA) for context), the Go Driver team suggests creating a new session every time this scenario arises.